### PR TITLE
Add promo projects from "More Terraforming Mars" kickstarter

### DIFF
--- a/cards-list.html
+++ b/cards-list.html
@@ -1654,7 +1654,7 @@
             <div class="tag tag3 tag-jovian "></div>
             <div class="number">#081</div>
             <div class="content ">
-                <div class="points points-big ">1/<span class="resource-tag tag-jovian"></span></div>
+                <div class="points ">1/<span class="resource-tag tag-jovian"></span></div>
                 <div class="tile city-tile"></div>*
                 <div class="description ">
                     (Place a city tile ON THE RESERVED AREA. 1 VP per Jovian tag you have.)
@@ -1836,14 +1836,14 @@
 
         <!--92-->
         <li onclick="getClickedCard();" class="filterDiv automated spaceTag jovianTag corporate ">
-            <div class="title background-color-automated ">IO Mining Industries </div>
+            <div class="title background-color-automated ">Io Mining Industries </div>
             <div class="price">41</div>
             <div class="tag tag1 tag-space "></div>
             <div class="tag tag2 tag-jovian "></div>
             <div class="number">#092</div>
             <div class="corporate-icon project-icon"></div>
             <div class="content ">
-                <div class="points points-big">1/<span class="tag-jovian resource-tag "></span></div>
+                <div class="points ">1/<span class="tag-jovian resource-tag "></span></div>
                 <div class="production-box production-box-size3">
                 <div class="production titanium"></div><div class="production titanium"></div><div class="production money">2</div>
                 </div>
@@ -5012,7 +5012,7 @@
 
               <!--p42-->
               <li onclick="getClickedCard();" class="filterDiv automated prelude earthTag spaceTag reqs" data-earth="2">
-                  <div class="title background-color-automated ">Space hotels</div>
+                  <div class="title background-color-automated ">Space Hotels</div>
                   <div class="price">12</div>
                   <div class="tag tag1 tag-space"></div>
                   <div class="tag tag2 tag-earth"></div>
@@ -6502,7 +6502,7 @@
             <div class="promo-icon project-icon"></div>
             <div class="number">#X14</div>
             <div class="content">
-              <div class="points points-big">1/<div class="resource asteroid" style="vertical-align: middle;"></div></div>
+              <div class="points ">1/<div class="resource asteroid" style="vertical-align: middle;"></div></div>
               <div class="red-arrow"></div>
               <div class="resource card"></div>*  <div class="resource-tag tag-space" style="margin-left:20px;margin-right:5px;"></div>: <div class="resource asteroid"></div>
               <div class="description">
@@ -6965,6 +6965,7 @@
             <div class="title background-color-automated">Outdoor Sports</div>
             <div class="price">8</div>
             <div class="number">#X38</div>
+            <div class="promo-icon project-icon"></div>
             <div class="content">
               <div class="points points-big">1</div>
               <div class="requirements">City/Ocean</div>
@@ -6983,6 +6984,7 @@
             <div class="price">31</div>
             <div class="tag tag1 tag-space"></div>
             <div class="number">#X44</div>
+            <div class="promo-icon project-icon"></div>
             <div class="content">
               <div class="points points-big">2</div>
               <div class="production-box production-box-size2">
@@ -6998,11 +7000,12 @@
           </li>
 
           <!--X45-->
-          <li onclick="getClickedCard();" class="filterDiv automated noneTag promo req" data-oxygen="4">
-              <div class="title background-color-automated ">Robot polinators</div>
+          <li onclick="getClickedCard();" class="filterDiv automated noneTag promo reqs" data-oxygen="4">
+              <div class="title background-color-automated ">Robot Pollinators</div>
               <div class="price">9</div>
               <div class="tag tag1 tag-microbe"></div>
               <div class="number">#X45</div>
+              <div class="promo-icon project-icon"></div>
               <div class="content ">
                   <div class="requirements ">4% O2</div>
                   <div class="production-box">
@@ -7011,7 +7014,7 @@
                   <br>
                   <div class="plant resource"></div> / <div class="plant resource-tag"></div>
                   <div class="description ">
-                    (Requires 4% oxygen. Increase your Plant production 1 step. Gain 1 plat for each Plant tag you have.)
+                    (Requires 4% oxygen. Increase your plant production 1 step. Gain 1 plant for each plant tag you have.)
                   </div>
               </div>
           </li>
@@ -7023,6 +7026,7 @@
             <div class="tag tag1 tag-building "></div>
             <div class="tag tag2 tag-power "></div>
             <div class="number">#X46</div>
+            <div class="promo-icon project-icon"></div>
             <div class="content ">
               EFFECT: CONVERTING ENERGY TO HEAT DURING PRODUCTION IS OPTIONAL FOR EACH ENERGY RESOURCE
               <br>
@@ -8454,7 +8458,7 @@
         </li>
 
         <li onclick="getClickedCard();" class="filterDiv prelude prelude-card jovianTag scienceTag">
-          <div class="title background-color-prelude">IO Research Outpost</div>
+          <div class="title background-color-prelude">Io Research Outpost</div>
           <div class="prelude-label">PRELUDE</div>
           <div class="number" style="margin-left:99px;">#P16</div>
           <div class="tag tag1 tag-jovian"></div>

--- a/cards-list.html
+++ b/cards-list.html
@@ -1654,7 +1654,7 @@
             <div class="tag tag3 tag-jovian "></div>
             <div class="number">#081</div>
             <div class="content ">
-                <div class="points ">1/<span class="resource-tag tag-jovian"></span></div>
+                <div class="points points-big">1/<span class="resource-tag tag-jovian"></span></div>
                 <div class="tile city-tile"></div>*
                 <div class="description ">
                     (Place a city tile ON THE RESERVED AREA. 1 VP per Jovian tag you have.)
@@ -1836,14 +1836,14 @@
 
         <!--92-->
         <li onclick="getClickedCard();" class="filterDiv automated spaceTag jovianTag corporate ">
-            <div class="title background-color-automated ">Io Mining Industries </div>
+            <div class="title background-color-automated ">Io Mining Industries</div>
             <div class="price">41</div>
             <div class="tag tag1 tag-space "></div>
             <div class="tag tag2 tag-jovian "></div>
             <div class="number">#092</div>
             <div class="corporate-icon project-icon"></div>
             <div class="content ">
-                <div class="points ">1/<span class="tag-jovian resource-tag "></span></div>
+                <div class="points points-big">1/<span class="tag-jovian resource-tag "></span></div>
                 <div class="production-box production-box-size3">
                 <div class="production titanium"></div><div class="production titanium"></div><div class="production money">2</div>
                 </div>
@@ -6502,7 +6502,7 @@
             <div class="promo-icon project-icon"></div>
             <div class="number">#X14</div>
             <div class="content">
-              <div class="points ">1/<div class="resource asteroid" style="vertical-align: middle;"></div></div>
+              <div class="points points-big">1/<div class="resource asteroid" style="vertical-align: middle;"></div></div>
               <div class="red-arrow"></div>
               <div class="resource card"></div>*  <div class="resource-tag tag-space" style="margin-left:20px;margin-right:5px;"></div>: <div class="resource asteroid"></div>
               <div class="description">

--- a/cards-list.html
+++ b/cards-list.html
@@ -7039,6 +7039,313 @@
               </div>
             </div>   
           </li>
+
+          <!--X48-->
+          <li onclick="getClickedCard();" class="filterDiv active noneTag promo">
+            <div class="title background-color-active ">Directed Heat Usage</div>
+            <div class="price">1</div>
+            <div class="number">#X48</div>
+            <div class="promo-icon project-icon"></div>
+            <div class="content ">
+              3 <div class="heat resource"></div> <div class="red-arrow"></div> 
+              <br>
+              <span class="money resource">4</span> OR <div class="plant resource"></div><div class="plant resource"></div>
+              <div class="description">
+                (Action: Spend 3 heat to either gain 4 MC or 2 plants.)
+              </div>   
+            </div>
+          </li>
+
+          <!--X50-->
+          <li onclick="getClickedCard();" class="filterDiv automated buildingTag promo reqs" data-oxygen="4">
+            <div class="title background-color-automated ">Aqueduct Systems</div>
+            <div class="price">9</div>
+            <div class="tag tag1 tag-building"></div>
+            <div class="number">#X50</div>
+            <div class="promo-icon project-icon"></div>
+            <div class="content ">
+              <div class="points points-big">1</div>
+              <div class="requirements ">City/Ocean</div><br>
+              <div class="resource card"><div class="card-icon tag-building"></div></div> 
+              <div class="resource card"><div class="card-icon tag-building"></div></div> 
+              <div class="resource card"><div class="card-icon tag-building"></div></div>
+              <div class="description ">
+                (Requires that you have a city next to an ocean. Reveal cards from the deck until you have revealed 3 building-tag cards. Take those into hand and discard the rest.)
+              </div>
+            </div>
+        </li>
+
+        <!--X51-->
+        <li onclick="getClickedCard();" class="filterDiv automated scienceTag promo" data-oxygen="4">
+          <div class="title background-color-automated ">Astra Mechanica</div>
+          <div class="price">7</div>
+          <div class="tag tag1 tag-science"></div>
+          <div class="number">#X51</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+              <div class="resource card"><div class="card-icon tag-event"></div></div> 
+              <div class="resource card"><div class="card-icon tag-event"></div></div> *
+              <div class="description ">
+                (RETURN 2 OF YOUR PLAYED EVENTS TO YOUR HAND. IT MAY NOT BE CARDS THAT PLACE SPECIAL TILES.)
+              </div>
+          </div>
+        </li>
+
+        <!--X52-->
+        <li onclick="getClickedCard();" class="filterDiv active buildingTag scienceTag promo">
+          <div class="title background-color-active ">Carbon Nanosystems</div>
+          <div class="price">14</div>
+          <div class="tag tag1 tag-building"></div>
+          <div class="tag tag2 tag-science"></div>
+          <div class="number">#X52</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="points points-big">1</div>
+            <div class="resource-tag tag-science"></div>  : <div class="resource" style="background: linear-gradient(darkgrey, black);">&nbsp;</div>
+            <div class="description">
+              (Effect: When you play a science tag, including this, add a graphene resource here.
+            </div>
+            <div class="resource-tag tag-space"></div> / <div class="resource-tag tag-city"></div>  : <div class="resource" style="background: linear-gradient(darkgrey, black);">&nbsp;</div> = <div class="money resource ">4</div>
+            <div class="description">
+              Effect: When paying for a space or city tag, graphenes may be used as 4 MC each.)
+            </div>   
+          </div>
+        </li>
+
+        <!--X53-->
+        <li onclick="getClickedCard();" class="filterDiv automated buildingTag promo">
+          <div class="title background-color-automated ">Cyberia Systems</div>
+          <div class="price">17</div>
+          <div class="tag tag1 tag-building"></div>
+          <div class="number">#X53</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="production-box"><div class="production steel"></div></div> 
+            <br> COPY 
+            <div class="production-box"><div class="resource-tag production-tag tag-building"></div></div>&nbsp;
+            <div class="production-box"><div class="resource-tag production-tag tag-building"></div></div>
+            <div class="description">
+              (Increase steel production 1 step. Copy the production boxes of 2 of your other cards with building tags.)
+            </div>   
+          </div>
+        </li>
+
+        <!--X56-->
+        <li onclick="getClickedCard();" class="filterDiv automated noneTag promo reqs" data-oxygen="4"">
+          <div class="title background-color-automated ">Hermetic Order of Mars</div>
+          <div class="price">10</div>
+          <div class="number">#X56</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="requirements requirements-max ">max 4% O2</div>
+            <div class="production-box"><div class="money production">2</div></div> 
+            <br>
+            <div class="resource money">1</div> / <div class="tile empty-tile-small"></div>*
+            <div class="description">
+              (Oxygen must be 4% or less. Increase your MC production 2 steps. Gain 1 MC per empty area adjacent to your tiles.)
+            </div>   
+          </div>
+        </li>
+
+        <!--X57-->
+        <li onclick="getClickedCard();" class="filterDiv active buildingTag promo">
+          <div class="title background-color-active ">Homeostasis Bureau</div>
+          <div class="price">16</div>
+          <div class="tag tag1 tag-building"></div>
+          <div class="number">#X57</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="tile temperature-tile"></div> : <div class="money resource ">3</div>
+            <div class="description">
+              (Effect: When you raise temperature, gain 3 MC.)
+            </div>
+            <br>
+            <div class="production-box production-box-size2">
+              <div class="production heat"></div>
+              <div class="production heat"></div>
+            </div>
+            <div class="description">
+              (Increase your heat production 2 steps.)
+            </div>   
+          </div>
+        </li>
+
+        <!--X58-->
+        <li onclick="getClickedCard();" class="filterDiv automated noneTag promo">
+          <div class="title background-color-automated ">Kaguya Tech</div>
+          <div class="price">10</div>
+          <div class="number">#X58</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="production-box" style="margin-right: 20px;"><div class="money production">2</div></div> 
+            <div class="card resource "></div>
+            <br>
+            <div class="minus"></div><div class="tile greenery-tile"></div>
+            <div class="plus"></div><div class="tile city-tile"></div> *
+            <div class="description">
+              (Increase MC production 2 steps. Draw 1 card. Remove 1 of your greenery tiles (does not affect oxygen). Place a city tile there, regardless of other restrictions. Gain placement bonuses as usual.)
+            </div>   
+          </div>
+        </li>
+
+        <!--X60-->
+        <li onclick="getClickedCard();" class="filterDiv active noneTag promo">
+          <div class="title background-color-active ">Mars Nomads</div>
+          <div class="price">13</div>
+          <div class="number">#X60</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="red-arrow"></div> MOVE 
+            <div class="resource" style="background: linear-gradient(yellow, gold);">&nbsp;</div>*
+            <div class="description">
+              (Action: Move the Nomads to an adjacent non-reserved, empty area and gain THE PLACEMENT BONUS as if placing a special tile there. No tiles may be placed on the Nomad area.)
+            </div> 
+            <br>
+            <div class="resource" style="background: linear-gradient(yellow, gold);">&nbsp;</div>*
+            <div class="description">
+              (PLACE THE NOMADS (a gold cube) on a non-reserved, empty area on the game board.)
+            </div>   
+          </div>
+        </li>
+
+        <!--X61-->
+        <li onclick="getClickedCard();" class="filterDiv active powerTag promo">
+          <div class="title background-color-active " style="font-size: 12px">Neptunian Power Consultants</div>
+          <div class="price">14</div>
+          <div class="tag tag1 tag-power"></div>
+          <div class="number">#X61</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="points">1/<div class="resource" style="background: linear-gradient(skyblue, cyan);">&nbsp;</div></div>
+            <div class="tile ocean-tile red-outline"></div> : <div class="minus"></div> 
+            <div class=" money resource ">5</div> (<span class="resource steel"></span>) 
+            <br>
+            <div class="plus"></div> 
+            <div class="production-box "><div class="energy production "></div></div> 
+            <div class="plus"></div> 
+            <div class="resource" style="background: linear-gradient(skyblue, cyan);">&nbsp;</div>
+            <div class="description">
+              (Effect: When any ocean is placed, you MAY pay 5 M€ (steel may be used) to raise energy production 1 step and add 1 hydroelectric resource to this card.)
+            </div> 
+            <div class="description">
+              (1 VP per hydroelectric resource on this card.)
+            </div>   
+          </div>
+        </li>
+
+        <!--X62-->
+        <li onclick="getClickedCard();" class="filterDiv active plantTag buildingTag promo reqs">
+          <div class="title background-color-active ">Martian Lumber Corps</div>
+          <div class="price">6</div>
+          <div class="tag tag1 tag-plant"></div>
+          <div class="tag tag2 tag-building"></div>
+          <div class="number">#X62</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="requirements">Forest Forest</div>
+            <div class="resource-tag tag-building"></div> : <div class="resource plant"></div> = <div class="money resource">3</div>
+            <div class="description">
+              (Effect: When paying for a building card, plants may be used as 3 MC each.)
+            </div>
+            <br>
+            <div class="production-box "><div class="plant production "></div></div> 
+            <div class="description">
+              (Requires that you have 2 greenery tiles. Increase plant production 1 step.)
+            </div>   
+          </div>
+        </li>
+
+        <!--X63-->
+        <li onclick="getClickedCard();" class="filterDiv active noneTag promo reqs" data-oxygen="4">
+          <div class="title background-color-active ">Red Ships</div>
+          <div class="price">2</div>
+          <div class="number">#X63</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="requirements ">4% O2</div>
+            <div class="red-arrow"></div> <div class="money resource ">1</div> / 
+            <div class="tile special-tile red-outline"></div><div class="tile ocean-tile" style="margin-left: -3px;""></div>*
+            <div class="description">
+              (Action: Gain 1 M€ for each CITY AND SPECIAL TILE ADJACENT TO OCEAN, regardless of owner.)
+            </div>
+            <br>
+            <div class="description">
+              (Requires 4% oxygen or more.)
+            </div> 
+          </div>
+        </li>
+
+        <!--X64-->
+        <li onclick="getClickedCard();" class="filterDiv active spaceTag earthTag promo">
+          <div class="title background-color-active ">Solar Logistics</div>
+          <div class="price">20</div>
+          <div class="tag tag1 tag-space"></div>
+          <div class="tag tag2 tag-earth"></div>
+          <div class="number">#X64</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="points points-big">1</div>
+            <div class="resource-tag tag-earth"></div> :
+            <div class="resource money">-2</div>
+            <div class="description">
+              (Effect: When you play an Earth tag, you pay 2 M€ less.
+            </div> 
+            <div class="resource-tag tag-space red-outline"></div>
+            <div class="resource-tag tag-event red-outline"></div> &nbsp;: 
+            <div class="resource card"></div>
+            <div class="description">
+              Effect: When any player plays a space event, you may draw a card.) 
+            </div>
+            <div class="resource titanium" style="margin-left:-64px"></div> 
+            <div class="resource titanium"></div>
+            <div class="description" style="margin-left:-64px;">
+              (Gain 2 titanium.)
+            </div>   
+          </div>
+        </li>
+  
+        <!--X65-->
+        <li onclick="getClickedCard();" class="filterDiv active powerTag buildingTag promo">
+          <div class="title background-color-active ">Teslaract</div>
+          <div class="price">14</div>
+          <div class="tag tag1 tag-building"></div>
+          <div class="tag tag2 tag-power"></div>
+          <div class="number">#X65</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="production-box"><div class="production energy "></div></div> 
+            <div class="red-arrow "></div> <div class="production-box"><div class="production plant "></div></div> 
+            <div class="description">
+              (Action: Spend energy production to increase plant production by the same amount.)
+            </div> 
+            <br>
+            <div class="tile rating"></div>
+            <div class="description">
+              (Raise your TR 1 step.)
+            </div>   
+          </div>
+        </li>
+
+        <!--X66-->
+        <li onclick="getClickedCard();" class="filterDiv active noneTag promo">
+          <div class="title background-color-active " style="font-size: 12px">St. Joseph of Cupertino Mission</div>
+          <div class="price">7</div>
+          <div class="number">#X65</div>
+          <div class="promo-icon project-icon"></div>
+          <div class="content ">
+            <div class="points">1/<div class="resource" style="background: linear-gradient(white, lightgrey);">&nbsp;</div></div>
+            <div class="money resource">5</div> (<div class="steel resource"></div>)
+            <div class="red-arrow "></div>
+            <div class="resource" style="background: linear-gradient(white, lightgrey);">&nbsp;</div>*
+            <div class="description">
+              (Action: Pay 5 M€ (steel may be used) to place a cathedral (silver cube) on a city tile. Max 1 per city. THE CITY OWNER MAY PAY 2 M€ TO DRAW 1 CARD.)
+            </div>
+            <br>
+            <div class="description">
+              (1 VP per cathedral in play.)
+            </div>   
+          </div>
+        </li>
    </ul>
 
   <!--CORPORATIONS-->

--- a/js/myscripts.js
+++ b/js/myscripts.js
@@ -1,3 +1,9 @@
+// Default counts 
+PROJECTS = 389;
+CORPORATIONS = 40;
+PRELUDES = 40;
+COLONIES = 11;
+GLOBALS = 36; 
 
 CONTAINER = 200; //the default height of the buttons container
 CONTENT_FILTERS = 125 //the default height of the Content filters area
@@ -18,21 +24,15 @@ else {
 
 function showAll() {
   var x, i;
-  displayedProjects = 374;
-  displayedCorporations = 40;
-  displayedPreludes = 40;
-  displayedColonies = 11;
-  displayedGlobals = 36;
-
   document.getElementById("buttonsContainer").style.display = "block";
 
   var elements = document.querySelectorAll('.ul-title');
   for (i=0; i<elements.length; i++){elements[i].style.display = "block";}
-  document.getElementById("totalProjects").innerHTML = displayedProjects;
-  document.getElementById("totalCorporations").innerHTML = displayedCorporations;
-  document.getElementById("totalPreludes").innerHTML = displayedPreludes;
-  document.getElementById("totalColonies").innerHTML = displayedColonies;
-  document.getElementById("totalGlobals").innerHTML = displayedGlobals;
+  document.getElementById("totalProjects").innerHTML = PROJECTS;
+  document.getElementById("totalCorporations").innerHTML = CORPORATIONS;
+  document.getElementById("totalPreludes").innerHTML = PRELUDES;
+  document.getElementById("totalColonies").innerHTML = COLONIES;
+  document.getElementById("totalGlobals").innerHTML = GLOBALS;
 
 
   //making all buttons inactive
@@ -327,17 +327,17 @@ function filterFunction(id) {
 
   //Display Cards Numbers
   displayedCards = document.querySelectorAll('li.show').length;
-  displayedCorporations = document.querySelectorAll('li.show.corporation').length;
-  displayedPreludes = document.querySelectorAll('li.show.prelude-card').length;
-  displayedColonies = document.querySelectorAll('li.show.colony-card').length;
-  displayedGlobals = document.querySelectorAll('li.show.global-card').length;
+  CORPORATIONS = document.querySelectorAll('li.show.corporation').length;
+  PRELUDES = document.querySelectorAll('li.show.prelude-card').length;
+  COLONIES = document.querySelectorAll('li.show.colony-card').length;
+  GLOBALS = document.querySelectorAll('li.show.global-card').length;
 
-  displayedProjects = displayedCards - displayedCorporations - displayedPreludes - displayedColonies - displayedGlobals;
-  document.getElementById("totalProjects").innerHTML = displayedProjects;
-  document.getElementById("totalCorporations").innerHTML = displayedCorporations;
-  document.getElementById("totalPreludes").innerHTML = displayedPreludes;
-  document.getElementById("totalColonies").innerHTML = displayedColonies;
-  document.getElementById("totalGlobals").innerHTML = displayedGlobals;
+  PROJECTS = displayedCards - CORPORATIONS - PRELUDES - COLONIES - GLOBALS;
+  document.getElementById("totalProjects").innerHTML = PROJECTS;
+  document.getElementById("totalCorporations").innerHTML = CORPORATIONS;
+  document.getElementById("totalPreludes").innerHTML = PRELUDES;
+  document.getElementById("totalColonies").innerHTML = COLONIES;
+  document.getElementById("totalGlobals").innerHTML = GLOBALS;
 
 
  //clearing all displayed cards


### PR DESCRIPTION
I have found your site very valuable, and I wanted to contribute!
The most recent Kickstarter can be found here: https://www.kickstarter.com/projects/strongholdgames/more-terraforming-mars/
All stretch goals have been reached, and the promo cards announced (submissions available online). 

With this PR, I have tried to add the project cards to your database. Please note that in one or two cases, the _exact_ wording involves a little guesswork, but cards' effects have been researched thoroughly!

I have also added the autumn 2023 promo card "Directed Heat Usage".

The following things need further addressing:
- New graphene resource icon for "Carbon Nanosystems"
- New hydroelectric resource icon for "Neptunian Power Consultants" (that card could use a face-lift)
- New City/Special tile icon for "Red Ships"

The following cards have **not** been implemented:
- "Icy Impactors" winter 2023 promo — not properly revealed, only speculated [here](https://boardgamegeek.com/thread/3148669/winter-2023-seasonal-promo) — I believe it should say:
  > (Action: Spend 10 M€ (titanium may be used) to add 2 asteroid here, or spend 1 asteroid here to place an ocean tile. FIRST PLAYER CHOOSES WHERE YOU MUST PLACE IT.)
- "Anti-Desertification Techniques" prelude
- "Tycho Magnetics" corporation
- "Established Methods" prelude — I believe it should say:
  > (Gain 30 M€. Then play standard projects, spending at least 30 M€.)
- "Giant Solar Collector" prelude
- "Kuiper Cooperative" corperation — I believe it should say:
  > (You start with 33 M€. Increase titanium production 1 step.) 
  > (Action: Add one asteroid here for every space tag you have. Effect: When playing the ASTEROID or AQUIFER standard projects, asteroids here may be used as 4 M€ each.)
- "Strategic Base Planning" prelude

I hope you find this useful!
